### PR TITLE
Create a Repository to handle live/memory files

### DIFF
--- a/public/dog/1.txt
+++ b/public/dog/1.txt
@@ -1,0 +1,1 @@
+Dog Breed: Corgi

--- a/public/dog/1.txt
+++ b/public/dog/1.txt
@@ -1,1 +1,0 @@
-Dog Breed: Corgi

--- a/src/main/java/application/App.java
+++ b/src/main/java/application/App.java
@@ -1,6 +1,6 @@
 package application;
-import http_protocol.MIMETypes;
-import http_protocol.StatusCode;
+import http_standards.MIMETypes;
+import http_standards.StatusCode;
 import http_server.Request;
 import http_server.Response;
 import http_server.Server;
@@ -38,7 +38,6 @@ public class App {
             response.head(bodyContent.getBytes(), MIMETypes.plain);
         });
 
-
         app.post("/echo_body", (Request request, Response response) -> {
             response.sendBody(request.getBody().getBytes(), request.getContentFileType());
             response.setStatus(StatusCode.ok);
@@ -64,12 +63,6 @@ public class App {
             String uniqueRoute = app.getUniqueRoute(request.getRoute());
             app.saveResource(uniqueRoute, request.getContentFileType(), request.getBody().getBytes());
             response.successfulPost(uniqueRoute);
-            System.err.println("created new resource!=" + uniqueRoute);
-        });
-
-        app.delete("/dog/1", (Request request, Response response) -> {
-            app.deleteResource(request.getRoute());
-            response.successfulDelete();
         });
 
         app.put("/cat/1", (Request request, Response response) -> {

--- a/src/main/java/application/App.java
+++ b/src/main/java/application/App.java
@@ -61,8 +61,9 @@ public class App {
 
         app.post("/dog", (Request request, Response response) -> {
             String uniqueRoute = app.getUniqueRoute(request.getRoute());
-            app.saveResource(uniqueRoute, request.getContentFileType(), request.getBody().getBytes());
-            response.successfulPost(uniqueRoute);
+            String resourceRoute = app.saveResource(uniqueRoute, request.getContentFileType(),
+                    request.getBody().getBytes());
+            response.successfulPost(resourceRoute);
         });
 
         app.put("/cat/1", (Request request, Response response) -> {

--- a/src/main/java/directory_page_creator/DirectoryPageCreator.java
+++ b/src/main/java/directory_page_creator/DirectoryPageCreator.java
@@ -1,8 +1,7 @@
 package directory_page_creator;
 
-import file_handler.FileHandler;
 import html_builder.HTMLBuilder;
-
+import repository.FileRepository;
 import java.util.List;
 
 public class DirectoryPageCreator {
@@ -20,7 +19,7 @@ public class DirectoryPageCreator {
 
         return builder
             .addHeader("<style>")
-            .addHeader(FileHandler.getFileContents(directoryCSSPath))
+            .addHeader(new FileRepository().getFileContents(directoryCSSPath))
             .addHeader("</style>")
             .append("<div class='directory-page'>")
             .append("<h1>Directory for " + staticDirectoryPath + "</h1>")

--- a/src/main/java/http_protocol/MIMETypes.java
+++ b/src/main/java/http_protocol/MIMETypes.java
@@ -1,6 +1,7 @@
 package http_protocol;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class MIMETypes {
     public static String plain = "text/plain";
@@ -18,5 +19,17 @@ public class MIMETypes {
 
     public static String getFileType(String mimeType) {
         return types.get(mimeType);
+    }
+
+    public static String getMIMEType(String fileType) {
+        String fileMIMEType = plain;
+        for(Map.Entry<String, String> entry : types.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (value.contains(fileType)) {
+                fileMIMEType = key;
+            }
+        }
+        return fileMIMEType;
     }
 }

--- a/src/main/java/http_server/Request.java
+++ b/src/main/java/http_server/Request.java
@@ -1,7 +1,7 @@
 package http_server;
 
-import http_protocol.Headers;
-import http_protocol.MIMETypes;
+import http_standards.Headers;
+import http_standards.MIMETypes;
 
 import java.util.HashMap;
 

--- a/src/main/java/http_server/Response.java
+++ b/src/main/java/http_server/Response.java
@@ -1,8 +1,8 @@
 package http_server;
 
-import http_protocol.Headers;
-import http_protocol.Methods;
-import http_protocol.StatusCode;
+import http_standards.Headers;
+import http_standards.Methods;
+import http_standards.StatusCode;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;

--- a/src/main/java/http_server/Response.java
+++ b/src/main/java/http_server/Response.java
@@ -81,9 +81,8 @@ public class Response {
     }
 
     public void sendFile(String path) {
-        String filePath = Router.getFullStaticDirectoryPath() + path;
+        String filePath = router.getFullStaticDirectoryPath() + path;
         byte[] file = router.getRepository().readFile(filePath);
-        System.err.println(file);
         this.body = file;
         setHeader(Headers.contentType, router.getRepository().getFileType(filePath));
         setHeader(Headers.contentLength, file.length + "");

--- a/src/main/java/http_server/Response.java
+++ b/src/main/java/http_server/Response.java
@@ -1,6 +1,5 @@
 package http_server;
 
-import file_handler.FileHandler;
 import http_protocol.Headers;
 import http_protocol.Methods;
 import http_protocol.StatusCode;
@@ -47,6 +46,7 @@ public class Response {
             return false;
         }
 
+
         return true;
     }
 
@@ -82,10 +82,10 @@ public class Response {
 
     public void sendFile(String path) {
         String filePath = Router.getFullStaticDirectoryPath() + path;
-        byte[] file = FileHandler.readFile(filePath);
+        byte[] file = router.getRepository().readFile(filePath);
         System.err.println(file);
         this.body = file;
-        setHeader(Headers.contentType, FileHandler.getFileType(filePath));
+        setHeader(Headers.contentType, router.getRepository().getFileType(filePath));
         setHeader(Headers.contentLength, file.length + "");
     }
 

--- a/src/main/java/http_server/ResponseByteAssembler.java
+++ b/src/main/java/http_server/ResponseByteAssembler.java
@@ -1,6 +1,6 @@
 package http_server;
 
-import http_protocol.Stringer;
+import http_standards.Stringer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.LinkedHashMap;

--- a/src/main/java/http_server/Router.java
+++ b/src/main/java/http_server/Router.java
@@ -1,9 +1,10 @@
 package http_server;
 
 import directory_page_creator.DirectoryPageCreator;
-import file_handler.FileHandler;
 import http_protocol.MIMETypes;
 import http_protocol.Methods;
+import repository.Repository;
+import repository.FileRepository;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -19,6 +20,7 @@ public class Router {
     private Set<String> methods;
     private Path basePath;
     private static Path fullStaticDirectoryPath;
+    private Repository repository;
 
     public Router() {
         this.routes = new HashMap<>();
@@ -29,6 +31,15 @@ public class Router {
         methods.add(Methods.put);
         methods.add(Methods.options);
         methods.add(Methods.delete);
+        repository = new FileRepository();
+    }
+
+    public void setRepository(Repository repository) {
+        this.repository = repository;
+    }
+
+    public Repository getRepository() {
+        return repository;
     }
 
     public HashMap<String, HashMap<String, Callback>> getRouter() {
@@ -117,7 +128,7 @@ public class Router {
 
     public void staticDirectory(String staticDirectoryRelativePath) {
         fullStaticDirectoryPath = Paths.get(basePath.toString(), staticDirectoryRelativePath);
-        List<String> directoryContents = FileHandler.readDirectoryContents(fullStaticDirectoryPath.toString());
+        List<String> directoryContents = repository.readDirectoryContents(fullStaticDirectoryPath.toString());
         createResourceRoutes(directoryContents, staticDirectoryRelativePath);
         createStaticDirectoryRoute(directoryContents, staticDirectoryRelativePath);
     }
@@ -147,7 +158,7 @@ public class Router {
     }
 
     public void saveResource(String resourcePath, String fileType, byte[] content) {
-        FileHandler.writeFile(getFullStaticDirectoryPath() + resourcePath, fileType, content);
+        repository.writeFile(getFullStaticDirectoryPath() + resourcePath, fileType, content);
         get(resourcePath, (Request request, Response response) -> {
             response.sendFile(resourcePath + "." + fileType);
         });
@@ -188,7 +199,7 @@ public class Router {
 
     public void deleteResource(String resourcePath) {
         System.err.println(getFullStaticDirectoryPath() + resourcePath);
-        FileHandler.deleteFile(getFullStaticDirectoryPath() + resourcePath);
+        repository.deleteFile(getFullStaticDirectoryPath() + resourcePath);
         routes.remove(resourcePath);
     }
 }

--- a/src/main/java/http_server/Router.java
+++ b/src/main/java/http_server/Router.java
@@ -8,6 +8,7 @@ import repository.FileRepository;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -21,6 +22,7 @@ public class Router {
     private Path basePath;
     private static Path fullStaticDirectoryPath;
     private Repository repository;
+    private static String dirPath;
 
     public Router() {
         this.routes = new HashMap<>();
@@ -52,6 +54,10 @@ public class Router {
 
     public static Path getFullStaticDirectoryPath() {
         return fullStaticDirectoryPath;
+    }
+
+    public static String dirPath() {
+        return dirPath;
     }
 
     public void basePath(Path path) {
@@ -127,17 +133,17 @@ public class Router {
     }
 
     public void staticDirectory(String staticDirectoryRelativePath) {
+        dirPath = staticDirectoryRelativePath;
         fullStaticDirectoryPath = Paths.get(basePath.toString(), staticDirectoryRelativePath);
         List<String> directoryContents = repository.readDirectoryContents(fullStaticDirectoryPath.toString());
         createResourceRoutes(directoryContents, staticDirectoryRelativePath);
-        createStaticDirectoryRoute(directoryContents, staticDirectoryRelativePath);
+        createStaticDirectoryRoute(staticDirectoryRelativePath);
     }
 
-    private void createStaticDirectoryRoute(List<String> directoryContents, String staticDirectoryRelativePath) {
-        String directoryHTML = new DirectoryPageCreator(directoryContents, staticDirectoryRelativePath).generateHTML();
-
+    private void createStaticDirectoryRoute(String staticDirectoryRelativePath) {
         get(staticDirectoryRelativePath, (Request request, Response response) -> {
-            response.sendBody(directoryHTML.getBytes(), MIMETypes.html);
+            List<String> directoryContents = repository.readDirectoryContents(fullStaticDirectoryPath.toString());
+            response.sendBody(new DirectoryPageCreator(directoryContents, staticDirectoryRelativePath).generateHTML().getBytes(), MIMETypes.html);
         });
     }
 
@@ -149,23 +155,35 @@ public class Router {
             get(filePath, (Request request, Response response) -> {
                 response.sendFile("/" + fileName);
             });
+        }
+    }
 
-            delete(filePath, (Request request, Response response) -> {
-                deleteResource(request.getRoute());
+    public String saveResource(String resourcePath, String fileType, byte[] content) {
+        repository.writeFile(getFullStaticDirectoryPath() + resourcePath, fileType, content);
+        createNewResourceRoutes(resourcePath, fileType);
+        return resourcePath;
+    }
+
+    private void createNewResourceRoutes(String resourcePath, String fileType) {
+        List<String> pathList = newResourcePaths(resourcePath, fileType);
+        for (int i = 0; i < pathList.size(); i++) {
+            get(pathList.get(i), (Request request, Response response) -> {
+                response.sendFile(resourcePath + "." + fileType);
+            });
+            delete(pathList.get(i), (Request request, Response response) -> {
+                deleteResource(resourcePath, fileType);
                 response.successfulDelete();
             });
         }
     }
 
-    public void saveResource(String resourcePath, String fileType, byte[] content) {
-        repository.writeFile(getFullStaticDirectoryPath() + resourcePath, fileType, content);
-        get(resourcePath, (Request request, Response response) -> {
-            response.sendFile(resourcePath + "." + fileType);
-        });
-        delete(resourcePath, (Request request, Response response) -> {
-            deleteResource(resourcePath + "." + fileType);
-            response.successfulDelete();
-        });
+    private List<String> newResourcePaths(String resourcePath, String fileType) {
+        return Arrays.asList(
+                resourcePath,
+                resourcePath + "." + fileType,
+                dirPath() + resourcePath,
+                dirPath() + resourcePath + "." + fileType
+        );
     }
 
     public String getUniqueRoute(String path) {
@@ -197,9 +215,16 @@ public class Router {
                 .max(Comparator.comparing(Integer::valueOf)).get();
     }
 
-    public void deleteResource(String resourcePath) {
-        System.err.println(getFullStaticDirectoryPath() + resourcePath);
-        repository.deleteFile(getFullStaticDirectoryPath() + resourcePath);
+    public void deleteResource(String resourcePath, String fileType) {
+        repository.deleteFile(getFullStaticDirectoryPath() + resourcePath + "." + fileType);
+        deleteResourceRoute(resourcePath);
+        deleteResourceRoute(resourcePath + "." + fileType);
+        deleteResourceRoute(dirPath() + resourcePath);
+        deleteResourceRoute(dirPath() + resourcePath + "." + fileType);
+        System.err.println(routes.keySet());
+    }
+
+    private void deleteResourceRoute(String resourcePath) {
         routes.remove(resourcePath);
     }
 }

--- a/src/main/java/http_server/Router.java
+++ b/src/main/java/http_server/Router.java
@@ -1,8 +1,8 @@
 package http_server;
 
 import directory_page_creator.DirectoryPageCreator;
-import http_protocol.MIMETypes;
-import http_protocol.Methods;
+import http_standards.MIMETypes;
+import http_standards.Methods;
 import repository.Repository;
 import repository.FileRepository;
 

--- a/src/main/java/http_server/Session.java
+++ b/src/main/java/http_server/Session.java
@@ -1,6 +1,6 @@
 package http_server;
 
-import http_protocol.RequestCreator;
+import http_standards.RequestCreator;
 
 public class Session implements Runnable {
     private final SocketWrapper client;

--- a/src/main/java/http_standards/Headers.java
+++ b/src/main/java/http_standards/Headers.java
@@ -1,4 +1,4 @@
-package http_protocol;
+package http_standards;
 
 public class Headers {
     public static String date = "Date";

--- a/src/main/java/http_standards/MIMETypes.java
+++ b/src/main/java/http_standards/MIMETypes.java
@@ -9,13 +9,24 @@ public class MIMETypes {
     public static String css = "text/css";
     public static String jpeg = "image/jpeg";
     public static String png = "image/png";
+    public static String json = "application/json";
+    public static String xml = "text/xml";
+    public static String javascript = "application/javascript";
+
     private static HashMap<String, String> types = new HashMap<String, String>() {{
         put(plain, "txt");
         put(html, "html");
         put(css, "css");
         put(jpeg, "jpg");
         put(png, "png");
+        put(json, "json");
+        put(xml, "xml");
+        put(javascript, "js");
     }};
+
+    public static boolean isMIMEType(String mimeType) {
+        return types.containsKey(mimeType);
+    }
 
     public static String getFileType(String mimeType) {
         return types.get(mimeType);

--- a/src/main/java/http_standards/MIMETypes.java
+++ b/src/main/java/http_standards/MIMETypes.java
@@ -1,4 +1,4 @@
-package http_protocol;
+package http_standards;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/main/java/http_standards/Methods.java
+++ b/src/main/java/http_standards/Methods.java
@@ -1,4 +1,4 @@
-package http_protocol;
+package http_standards;
 
 import java.util.Arrays;
 import java.util.List;

--- a/src/main/java/http_standards/Parser.java
+++ b/src/main/java/http_standards/Parser.java
@@ -1,4 +1,4 @@
-package http_protocol;
+package http_standards;
 
 import java.util.HashMap;
 

--- a/src/main/java/http_standards/RequestCreator.java
+++ b/src/main/java/http_standards/RequestCreator.java
@@ -1,4 +1,4 @@
-package http_protocol;
+package http_standards;
 
 import http_server.Request;
 

--- a/src/main/java/http_standards/StatusCode.java
+++ b/src/main/java/http_standards/StatusCode.java
@@ -1,4 +1,4 @@
-package http_protocol;
+package http_standards;
 
 public class StatusCode {
     public static String ok = "200 OK";

--- a/src/main/java/http_standards/Stringer.java
+++ b/src/main/java/http_standards/Stringer.java
@@ -1,4 +1,4 @@
-package http_protocol;
+package http_standards;
 
 public class Stringer {
     public static String crlf = "\r\n";

--- a/src/main/java/repository/FileRepository.java
+++ b/src/main/java/repository/FileRepository.java
@@ -1,4 +1,6 @@
-package file_handler;
+package repository;
+
+import com.google.common.primitives.Chars;
 
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -20,8 +22,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-public class FileHandler {
-    public static List<String> readDirectoryContents(String path) {
+public class FileRepository implements Repository {
+    public List<String> readDirectoryContents(String path) {
         List<String> fileList = new ArrayList<String>();
 
         Path dir = Paths.get(path);
@@ -37,7 +39,7 @@ public class FileHandler {
         return fileList;
     }
 
-    public static byte[] readFile(String path) {
+    public byte[] readFile(String path) {
         Path file = Paths.get(path);
         try {
             byte[] fileBytes = Files.readAllBytes(file);
@@ -74,7 +76,7 @@ public class FileHandler {
         return fileContents;
     }
 
-    public static String getFileType(String path) {
+    public String getFileType(String path) {
         Path file = Paths.get(path);
         try {
             return Files.probeContentType(file);
@@ -84,10 +86,10 @@ public class FileHandler {
         }
     }
 
-    public static void writeFile(String intendedFilePath, String fileType, byte[] fileContents) {
+    public void writeFile(String intendedFilePath, String fileType, byte[] fileContents) {
         Path path = Paths.get(intendedFilePath + "." + fileType);
 
-        createDirectories(Paths.get(trimLastResource(intendedFilePath)));
+        createDirectories(Paths.get(Repository.trimLastResource(intendedFilePath)));
 
         try (OutputStream out = new BufferedOutputStream(Files.newOutputStream(path))) {
             out.write(fileContents, 0, fileContents.length);
@@ -96,7 +98,7 @@ public class FileHandler {
         }
     }
 
-    public static void createDirectories(Path directoryPaths) {
+    public void createDirectories(Path directoryPaths) {
         try {
             Set<PosixFilePermission> perms = PosixFilePermissions.fromString("rwxrwxrwx");
             FileAttribute<Set<PosixFilePermission>> attr = PosixFilePermissions.asFileAttribute(perms);
@@ -106,7 +108,7 @@ public class FileHandler {
         }
     }
 
-    public static void deleteDirectory(String directoryPath) {
+    public void deleteDirectory(String directoryPath) {
         List<String> directoryContents = readDirectoryContents(directoryPath);
         for (int i = 0; i < directoryContents.size(); i++) {
             deleteFile(directoryPath + "/" + directoryContents.get(i));
@@ -114,7 +116,7 @@ public class FileHandler {
         deleteFile(directoryPath);
     }
 
-    public static void deleteFile(String filePath) {
+    public void deleteFile(String filePath) {
         Path path = Paths.get(filePath);
 
         try {
@@ -125,11 +127,6 @@ public class FileHandler {
         } catch (IOException x) {
             System.err.println(x);
         }
-    }
-
-    public static String trimLastResource(String path) {
-        int lastSlashIndex = path.lastIndexOf("/");
-        return path.substring(0, lastSlashIndex);
     }
 
 }

--- a/src/main/java/repository/Repository.java
+++ b/src/main/java/repository/Repository.java
@@ -1,6 +1,5 @@
 package repository;
 
-import java.nio.file.Path;
 import java.util.List;
 
 public interface Repository {
@@ -8,11 +7,5 @@ public interface Repository {
     byte[] readFile(String path);
     String getFileType(String path);
     void writeFile(String intendedFilePath, String fileType, byte[] fileContents);
-    void createDirectories(Path directoryPaths);
-    void deleteDirectory(String directoryPath);
     void deleteFile(String filePath);
-    static String trimLastResource(String path) {
-        int lastSlashIndex = path.lastIndexOf("/");
-        return path.substring(0, lastSlashIndex);
-    }
 }

--- a/src/main/java/repository/Repository.java
+++ b/src/main/java/repository/Repository.java
@@ -1,0 +1,18 @@
+package repository;
+
+import java.nio.file.Path;
+import java.util.List;
+
+public interface Repository {
+    List<String> readDirectoryContents(String path);
+    byte[] readFile(String path);
+    String getFileType(String path);
+    void writeFile(String intendedFilePath, String fileType, byte[] fileContents);
+    void createDirectories(Path directoryPaths);
+    void deleteDirectory(String directoryPath);
+    void deleteFile(String filePath);
+    static String trimLastResource(String path) {
+        int lastSlashIndex = path.lastIndexOf("/");
+        return path.substring(0, lastSlashIndex);
+    }
+}

--- a/src/test/java/directory_page_creator/DirectoryPageCreatorTest.java
+++ b/src/test/java/directory_page_creator/DirectoryPageCreatorTest.java
@@ -1,48 +1,44 @@
 package directory_page_creator;
 
-import file_handler.FileHandler;
+import mocks.MockRepository;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import repository.Repository;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 
 public class DirectoryPageCreatorTest {
+    Repository repository = new MockRepository("/public");
     @BeforeEach
     public void prepFiles() {
-        FileHandler.deleteDirectory("./public/dog");
-        FileHandler.deleteDirectory("./public/cat");
-        FileHandler.deleteDirectory("./public/delete_me.txt");
+        repository.deleteDirectory("./public/dog");
+        repository.deleteDirectory("./public/cat");
+        repository.deleteDirectory("./public/delete_me.txt");
     }
 
     @AfterEach
     public void cleanUpFiles() {
-        FileHandler.deleteDirectory("./public/dog");
-        FileHandler.deleteDirectory("./public/cat");
+        repository.deleteDirectory("./public/dog");
+        repository.deleteDirectory("./public/cat");
     }
 
     @Test
     public void static_files_in_public_directory_are_rendered_as_a_HTML_page_with_contents_listed() {
         String path = "./public";
-        List<String> directoryContents = new FileHandler().readDirectoryContents(path);
+        List<String> directoryContents = repository.readDirectoryContents(path);
+        System.err.println(directoryContents);
         DirectoryPageCreator directoryPageCreator = new DirectoryPageCreator(directoryContents, "/public");
+        String page = directoryPageCreator.generateHTML();
+        String homeList = "<li class='bullets'><a href='/public/Home.html'>Home.html</a></li>\n";
+        String japanList = "<li class='bullets'><a href='/public/japan.png'>japan.png</a></li>\n";
+        String waterList =  "<li class='bullets'><a href='/public/water.png'>water.png</a></li>\n";
+        String turtleList = "<li class='bullets'><a href='/public/TurtleTab.txt'>TurtleTab.txt</a></li>\n";
 
-        String directoryBody = "<!DOCTYPE html>\n" +
-                "<html lang=\"en\">\n" +
-                "<head>\n" +
-                "<meta charset=\"UTF-8\">\n" +
-                "<title>Home Page</title>\n" +
-                "<style>.directory-page {    padding: 20px;    font-family: -apple-system, BlinkMacSystemFont, \"Segoe UI\", \"Roboto\", \"Oxygen\", \"Ubuntu\", \"Cantarell\", \"Fira Sans\",    \"Droid Sans\", \"Helvetica Neue\", sans-serif;    font-size: 20px;}.bullets {    color: grey;    margin: 20px 0px;}h1 {    text-align: center;    color: dark-grey;    font-weight: 600;    font-size: 42px;}hr {    color: grey;    border-weight: 2px;}</style></head>\n" +
-                "<body>\n" +
-                "<div class='directory-page'><h1>Directory for /public</h1><hr /><ul>\n" +
-                "<li class='bullets'><a href='/public/Home.html'>Home.html</a></li>\n" +
-                "<li class='bullets'><a href='/public/TurtleTab.txt'>TurtleTab.txt</a></li>\n" +
-                "<li class='bullets'><a href='/public/japan.png'>japan.png</a></li>\n" +
-                "<li class='bullets'><a href='/public/water.png'>water.png</a></li>\n" +
-                "</ul>\n" +
-                "</div></body>\n" +
-                "</html>";
-
-        assertEquals(directoryBody, directoryPageCreator.generateHTML());
+        assertEquals(true, page.contains(homeList));
+        assertEquals(true, page.contains(japanList));
+        assertEquals(true, page.contains(waterList));
+        assertEquals(true, page.contains(turtleList));
     }
 }

--- a/src/test/java/directory_page_creator/DirectoryPageCreatorTest.java
+++ b/src/test/java/directory_page_creator/DirectoryPageCreatorTest.java
@@ -1,7 +1,7 @@
 package directory_page_creator;
 
+import http_standards.MIMETypes;
 import mocks.MockRepository;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import repository.Repository;
@@ -10,18 +10,15 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.List;
 
 public class DirectoryPageCreatorTest {
-    Repository repository = new MockRepository("/public");
-    @BeforeEach
-    public void prepFiles() {
-        repository.deleteDirectory("./public/dog");
-        repository.deleteDirectory("./public/cat");
-        repository.deleteDirectory("./public/delete_me.txt");
-    }
+    Repository repository;
 
-    @AfterEach
-    public void cleanUpFiles() {
-        repository.deleteDirectory("./public/dog");
-        repository.deleteDirectory("./public/cat");
+    @BeforeEach
+    public void createRepository() {
+        repository = new MockRepository("/public");
+        repository.writeFile("./public/Home.html", MIMETypes.html, "<!DOCTYPE html>\n".getBytes());
+        repository.writeFile("./public/TurtleTab.txt", MIMETypes.plain, "TurtleTabs a Google".getBytes());
+        repository.writeFile("./public/water.png", MIMETypes.png, "water image".getBytes());
+        repository.writeFile("./public/japan.png", MIMETypes.png, "japan image".getBytes());
     }
 
     @Test

--- a/src/test/java/http_server/RequestTest.java
+++ b/src/test/java/http_server/RequestTest.java
@@ -1,7 +1,7 @@
 package http_server;
 
-import http_protocol.RequestCreator;
-import http_protocol.Stringer;
+import http_standards.RequestCreator;
+import http_standards.Stringer;
 import java.util.HashMap;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/src/test/java/http_server/ResponseTest.java
+++ b/src/test/java/http_server/ResponseTest.java
@@ -1,10 +1,10 @@
 package http_server;
 
-import http_protocol.Headers;
-import http_protocol.MIMETypes;
-import http_protocol.RequestCreator;
-import http_protocol.StatusCode;
-import http_protocol.Stringer;
+import http_standards.Headers;
+import http_standards.MIMETypes;
+import http_standards.RequestCreator;
+import http_standards.StatusCode;
+import http_standards.Stringer;
 import mocks.MockRepository;
 import mocks.MockRouter;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/http_server/ResponseTest.java
+++ b/src/test/java/http_server/ResponseTest.java
@@ -1,17 +1,20 @@
 package http_server;
 
-import file_handler.FileHandler;
 import http_protocol.Headers;
 import http_protocol.MIMETypes;
 import http_protocol.RequestCreator;
 import http_protocol.StatusCode;
 import http_protocol.Stringer;
+import mocks.MockRepository;
 import mocks.MockRouter;
 import org.junit.jupiter.api.Test;
+import repository.Repository;
+
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResponseTest {
-    Router mockRouter = new MockRouter().getApp();
+    Repository mockRepository = new MockRepository("/public");
+    Router mockRouter = new MockRouter().getApp(mockRepository);
 
     private Response createResponseObject(String request) {
         Request requestData = RequestCreator.from(request);
@@ -77,7 +80,7 @@ public class ResponseTest {
         String request = "GET /simple_get HTTP/1.1" + Stringer.crlf;
         Response response = createResponseObject(request);
         response.sendFile("/water.png");
-        byte[] readImage = FileHandler.readFile("./public/water.png");
+        byte[] readImage = mockRepository.readFile("./public/water.png");
 
         assertEquals(StatusCode.ok, response.getStatus());
         assertEquals(MIMETypes.png, response.getHeaders().get(Headers.contentType));

--- a/src/test/java/http_server/ResponseTest.java
+++ b/src/test/java/http_server/ResponseTest.java
@@ -7,14 +7,25 @@ import http_standards.StatusCode;
 import http_standards.Stringer;
 import mocks.MockRepository;
 import mocks.MockRouter;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import repository.Repository;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class ResponseTest {
-    Repository mockRepository = new MockRepository("/public");
-    Router mockRouter = new MockRouter().getApp(mockRepository);
+    Repository mockRepository;
+    Router mockRouter;
+
+    @BeforeEach
+    public void cleanRepository() {
+        mockRepository = new MockRepository("/public");
+        mockRepository.writeFile("./public/Home.html", MIMETypes.html, "<!DOCTYPE html>\n".getBytes());
+        mockRepository.writeFile("./public/TurtleTab.txt", MIMETypes.plain, "TurtleTabs a Google".getBytes());
+        mockRepository.writeFile("./public/water.png", MIMETypes.png, "water image".getBytes());
+        mockRepository.writeFile("./public/japan.png", MIMETypes.png, "japan image".getBytes());
+        mockRouter = new MockRouter(mockRepository).getApp();
+    }
 
     private Response createResponseObject(String request) {
         Request requestData = RequestCreator.from(request);

--- a/src/test/java/http_server/RouterTest.java
+++ b/src/test/java/http_server/RouterTest.java
@@ -1,8 +1,8 @@
 package http_server;
 
-import http_protocol.MIMETypes;
-import http_protocol.RequestCreator;
-import http_protocol.Stringer;
+import http_standards.MIMETypes;
+import http_standards.RequestCreator;
+import http_standards.Stringer;
 import java.nio.file.Paths;
 import java.util.HashMap;
 import org.junit.jupiter.api.BeforeEach;

--- a/src/test/java/http_server/RouterTest.java
+++ b/src/test/java/http_server/RouterTest.java
@@ -1,6 +1,8 @@
 package http_server;
 
 import http_standards.MIMETypes;
+import http_standards.Methods;
+import http_standards.Parser;
 import http_standards.RequestCreator;
 import http_standards.Stringer;
 import java.nio.file.Paths;
@@ -9,6 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class RouterTest {
@@ -175,5 +179,31 @@ public class RouterTest {
     @Test
     public void Router_can_set_first_resource_id_for_a_parent_route() {
         assertEquals("/dog/1", router.getUniqueRoute("/dog"));
+    }
+
+    @Test
+    public void Router_can_save_resources() {
+        router.basePath(Paths.get(System.getProperty("user.dir")));
+        router.staticDirectory("/public");
+        router.saveResource("/dog/1", "html", "DELETE ME".getBytes());
+
+        assertEquals(true, router.getMethodCollection("/dog/1").containsKey(Methods.get));
+        assertEquals(true, router.getMethodCollection("/dog/1.html").containsKey(Methods.get));
+        assertEquals(true, router.getMethodCollection("/public/dog/1").containsKey(Methods.get));
+        assertEquals(true, router.getMethodCollection("/public/dog/1.html").containsKey(Methods.get));
+    }
+
+    @Test
+    public void Router_can_delete_resources_and_routes() {
+        router.basePath(Paths.get(System.getProperty("user.dir")));
+        router.staticDirectory("/public");
+        router.saveResource("/delete_me", "txt", "DELETE ME".getBytes());
+
+        router.deleteResource("/delete_me", "txt");
+
+        assertEquals(false, router.getMethodCollection("/delete_me").containsKey(Methods.get));
+        assertEquals(false, router.getMethodCollection("/delete_me.txt").containsKey(Methods.get));
+        assertEquals(false, router.getMethodCollection("/public/delete_me").containsKey(Methods.get));
+        assertEquals(false, router.getMethodCollection("/public/delete_me.txt").containsKey(Methods.get));
     }
 }

--- a/src/test/java/http_server/ServerTest.java
+++ b/src/test/java/http_server/ServerTest.java
@@ -1,13 +1,12 @@
 package http_server;
 
 import html_builder.HTMLBuilder;
-import http_protocol.Headers;
-import http_protocol.Parser;
-import http_protocol.Stringer;
+import http_standards.Headers;
+import http_standards.Parser;
+import http_standards.Stringer;
 import mocks.MockClientSocket;
 import mocks.MockRepository;
 import mocks.MockRouter;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import repository.Repository;

--- a/src/test/java/http_standards/MIMETypesTest.java
+++ b/src/test/java/http_standards/MIMETypesTest.java
@@ -1,0 +1,36 @@
+package http_standards;
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class MIMETypesTest {
+    @Test
+    public void given_a_plain_MIMEType_return_file_type() {
+        assertEquals("txt", MIMETypes.getFileType(MIMETypes.plain));
+    }
+
+    @Test
+    public void given_a_image_MIMEType_return_file_type() {
+        assertEquals("png", MIMETypes.getFileType(MIMETypes.png));
+    }
+
+    @Test
+    public void given_a_image_type_return_MIMEType() {
+        assertEquals(MIMETypes.png, MIMETypes.getMIMEType("png"));
+    }
+
+    @Test
+    public void given_a_text_type_return_MIMEType() {
+        assertEquals(MIMETypes.json, MIMETypes.getMIMEType("json"));
+    }
+
+    @Test
+    public void verify_whether_a_value_is_a_mime_type() {
+        assertEquals(true, MIMETypes.isMIMEType(MIMETypes.plain));
+    }
+
+    @Test
+    public void verify_whether_a_value_is_not_a_mime_type() {
+        assertEquals(false, MIMETypes.isMIMEType("png"));
+    }
+}

--- a/src/test/java/mocks/MockRepository.java
+++ b/src/test/java/mocks/MockRepository.java
@@ -3,8 +3,6 @@ package mocks;
 import http_standards.MIMETypes;
 import repository.MockFile;
 import repository.Repository;
-
-import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,67 +13,35 @@ public class MockRepository implements Repository  {
 
     public MockRepository(String directory) {
         this.directory = directory;
-
-        memoryRepository.put(filePath("/Home.html"), new MockFile("Home.html", MIMETypes.html,
-                "<!DOCTYPE html>\n".getBytes()));
-
-        memoryRepository.put(filePath("/TurtleTab.txt"), new MockFile("TurtleTab.txt", MIMETypes.plain, (
-                "TurtleTabs a Google").getBytes()));
-
-        memoryRepository.put(filePath("/water.png"), new MockFile("water.png", MIMETypes.png,
-                "water image".getBytes()));
-
-        memoryRepository.put(filePath("/japan.png"), new MockFile("japan.png", MIMETypes.png,
-                "japan image".getBytes()));
-    }
-
-    private String filePath(String path) {
-        return directory + path;
     }
 
     public List<String> readDirectoryContents(String path) {
         List<String> directory = memoryRepository
                 .keySet()
                 .stream()
-                .filter(x -> x.startsWith(validatedPath(path)))
-                .map(x -> x.substring(validatedPath(path).length() + 1))
+                .filter(filePath -> filePath.startsWith(validatedPath(path)))
+                .map(filePath -> filePath.substring(validatedPath(path).length() + 1))
                 .collect(Collectors.toList());
         return directory;
     }
 
     public byte[] readFile(String path) {
-        path = validatedPath(path);
-        if (memoryRepository.containsKey(path)) {
-            return memoryRepository.get(path).content();
-        } else if (memoryRepository.containsKey(trimmedPath(path)))  {
-            return memoryRepository.get(trimmedPath(path)).content();
-        } else {
-            throw new NullPointerException();
-        }
+        return getFile(path).content();
     }
 
     public String getFileType(String path) {
-        path = validatedPath(path);
-        if (memoryRepository.containsKey(path)) {
-            return memoryRepository.get(path).type();
-        } else if (memoryRepository.containsKey(trimmedPath(path)))  {
-            System.err.println(trimmedPath(path));
-            return memoryRepository.get(trimmedPath(path)).type();
-        } else {
-            return "";
-        }
+        return getFile(path).type();
     }
+
     public void writeFile(String intendedFilePath, String fileType, byte[] fileContents) {
         intendedFilePath = validatedPath(intendedFilePath);
         String fileName = intendedFilePath.substring(intendedFilePath.lastIndexOf("/"));
-        memoryRepository.put(intendedFilePath, new MockFile(fileName, MIMETypes.getMIMEType(fileType), fileContents));
+        String validatedFileType = MIMETypes.isMIMEType(fileType) ? fileType : MIMETypes.getMIMEType(fileType);
+
+        memoryRepository.put(intendedFilePath, new MockFile(fileName, validatedFileType, fileContents));
     }
-    public void createDirectories(Path directoryPaths) {
-        return;
-    }
-    public void deleteDirectory(String directoryPath) {
-        return;
-    }
+
+
     public void deleteFile(String filePath) {
         memoryRepository.remove(validatedPath(filePath));
     }
@@ -84,7 +50,19 @@ public class MockRepository implements Repository  {
         return path.startsWith(directory) ? path : path.substring(path.indexOf(directory));
     }
 
-    public String trimmedPath(String path) {
+    private String trimmedPath(String path) {
         return path.substring(0, path.lastIndexOf("."));
+    }
+
+    private MockFile getFile(String path) {
+        path = validatedPath(path);
+        if (memoryRepository.containsKey(path)) {
+            return memoryRepository.get(path);
+        } else if (memoryRepository.containsKey(trimmedPath(path)))  {
+            return memoryRepository.get(trimmedPath(path));
+        } else {
+            System.err.println("File path not valid");
+            throw new NullPointerException();
+        }
     }
 }

--- a/src/test/java/mocks/MockRepository.java
+++ b/src/test/java/mocks/MockRepository.java
@@ -1,0 +1,91 @@
+package mocks;
+
+import http_protocol.MIMETypes;
+import repository.MockFile;
+import repository.Repository;
+
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MockRepository implements Repository  {
+    String directory;
+    private HashMap<String, MockFile> memoryRepository = new HashMap<>();
+
+    public MockRepository(String directory) {
+        this.directory = directory;
+
+        memoryRepository.put(filePath("/Home.html"), new MockFile("Home.html", MIMETypes.html,
+                "<!DOCTYPE html>\n".getBytes()));
+
+        memoryRepository.put(filePath("/TurtleTab.txt"), new MockFile("TurtleTab.txt", MIMETypes.plain, (
+                "TurtleTabs a Google").getBytes()));
+
+        memoryRepository.put(filePath("/water.png"), new MockFile("water.png", MIMETypes.png,
+                "water image".getBytes()));
+
+        memoryRepository.put(filePath("/japan.png"), new MockFile("japan.png", MIMETypes.png,
+                "japan image".getBytes()));
+    }
+
+    private String filePath(String path) {
+        return directory + path;
+    }
+
+    public List<String> readDirectoryContents(String path) {
+        List<String> directory = memoryRepository
+                .keySet()
+                .stream()
+                .filter(x -> x.startsWith(validatedPath(path)))
+                .map(x -> x.substring(validatedPath(path).length() + 1))
+                .collect(Collectors.toList());
+        return directory;
+    }
+
+    public byte[] readFile(String path) {
+        path = validatedPath(path);
+        if (memoryRepository.containsKey(path)) {
+            return memoryRepository.get(path).content();
+        } else if (memoryRepository.containsKey(trimmedPath(path)))  {
+            System.err.println(trimmedPath(path));
+            return memoryRepository.get(trimmedPath(path)).content();
+        } else {
+            throw new NullPointerException();
+        }
+    }
+
+    public String getFileType(String path) {
+        path = validatedPath(path);
+        if (memoryRepository.containsKey(path)) {
+            return memoryRepository.get(path).type();
+        } else if (memoryRepository.containsKey(trimmedPath(path)))  {
+            System.err.println(trimmedPath(path));
+            return memoryRepository.get(trimmedPath(path)).type();
+        } else {
+            return "";
+        }
+    }
+    public void writeFile(String intendedFilePath, String fileType, byte[] fileContents) {
+        intendedFilePath = validatedPath(intendedFilePath);
+        String fileName = intendedFilePath.substring(intendedFilePath.lastIndexOf("/"));
+        memoryRepository.put(intendedFilePath, new MockFile(fileName, MIMETypes.getMIMEType(fileType), fileContents));
+    }
+    public void createDirectories(Path directoryPaths) {
+        return;
+    }
+    public void deleteDirectory(String directoryPath) {
+        return;
+    }
+    public void deleteFile(String filePath) {
+        memoryRepository.remove(validatedPath(filePath));
+    }
+
+    public String validatedPath(String path) {
+        return path.startsWith(directory) ? path : path.substring(path.indexOf(directory));
+    }
+
+    public String trimmedPath(String path) {
+        return path.substring(0, path.lastIndexOf("."));
+    }
+}

--- a/src/test/java/mocks/MockRepository.java
+++ b/src/test/java/mocks/MockRepository.java
@@ -1,6 +1,6 @@
 package mocks;
 
-import http_protocol.MIMETypes;
+import http_standards.MIMETypes;
 import repository.MockFile;
 import repository.Repository;
 
@@ -48,7 +48,6 @@ public class MockRepository implements Repository  {
         if (memoryRepository.containsKey(path)) {
             return memoryRepository.get(path).content();
         } else if (memoryRepository.containsKey(trimmedPath(path)))  {
-            System.err.println(trimmedPath(path));
             return memoryRepository.get(trimmedPath(path)).content();
         } else {
             throw new NullPointerException();

--- a/src/test/java/mocks/MockRouter.java
+++ b/src/test/java/mocks/MockRouter.java
@@ -4,19 +4,23 @@ import http_protocol.MIMETypes;
 import http_server.Request;
 import http_server.Response;
 import http_server.Router;
+import repository.Repository;
+
 import java.nio.file.Paths;
 
 public class MockRouter {
-    public Router getApp() {
-        return createRouter();
+    public Router getApp(Repository repository) {
+        return createRouter(repository);
     }
 
-    private Router createRouter() {
+    private Router createRouter(Repository repository) {
         Router app = new Router();
 
         app.basePath(Paths.get(System.getProperty("user.dir")));
 
         app.staticDirectory("/public");
+
+        app.setRepository(repository);
 
         app.get("/", (Request request, Response response) -> {
             response.redirect("/public");

--- a/src/test/java/mocks/MockRouter.java
+++ b/src/test/java/mocks/MockRouter.java
@@ -1,6 +1,6 @@
 package mocks;
 
-import http_protocol.MIMETypes;
+import http_standards.MIMETypes;
 import http_server.Request;
 import http_server.Response;
 import http_server.Router;

--- a/src/test/java/mocks/MockRouter.java
+++ b/src/test/java/mocks/MockRouter.java
@@ -9,11 +9,17 @@ import repository.Repository;
 import java.nio.file.Paths;
 
 public class MockRouter {
-    public Router getApp(Repository repository) {
-        return createRouter(repository);
+    Repository repository;
+
+    public MockRouter(Repository repository) {
+        this.repository = repository;
     }
 
-    private Router createRouter(Repository repository) {
+    public Router getApp() {
+        return createRouter();
+    }
+
+    private Router createRouter() {
         Router app = new Router();
 
         app.basePath(Paths.get(System.getProperty("user.dir")));
@@ -56,8 +62,9 @@ public class MockRouter {
 
         app.post("/dog", (Request request, Response response) -> {
             String uniqueRoute = app.getUniqueRoute(request.getRoute());
-            app.saveResource(uniqueRoute, request.getContentFileType(), request.getBody().getBytes());
-            response.successfulPost(uniqueRoute);
+            String resourceRoute = app.saveResource(uniqueRoute, request.getContentFileType(),
+                    request.getBody().getBytes());
+            response.successfulPost(resourceRoute);
         });
 
         app.put("/cat/1", (Request request, Response response) -> {

--- a/src/test/java/repository/FileRepositoryTest.java
+++ b/src/test/java/repository/FileRepositoryTest.java
@@ -1,10 +1,23 @@
 package repository;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class FileRepositoryTest {
-    FileRepository fileHandler = new FileRepository();
+    FileRepository fileHandler;
+
+    @BeforeEach
+    public void cleanRepository() {
+        fileHandler = new FileRepository();
+    }
+
+    @AfterEach
+    public void deleteRepository() {
+        fileHandler.deleteDirectory("./public/test");
+    }
+
 
     @Test
     public void static_files_in_public_directory_are_rendered_as_a_HTML_page_with_contents_listed() {
@@ -72,40 +85,61 @@ public class FileRepositoryTest {
 
     @Test
     public void file_can_be_written_to_directory() {
-        String path = "./public/dog/1";
+        String path = "./public/test/1";
         String body = "Dog Breed: Corgi";
         fileHandler.writeFile(path, "txt", body.getBytes());
-        assertEquals(body, new String(fileHandler.readFile("./public/dog/1.txt")));
+        assertEquals(body, new String(fileHandler.readFile("./public/test/1.txt")));
     }
 
     @Test
     public void path_can_trim_last_resource() {
-        String path = "./public/dog/1";
-        assertEquals("./public/dog", Repository.trimLastResource(path));
+        String path = "./public/test/1";
+        assertEquals("./public/test", fileHandler.trimLastResource(path));
     }
 
     @Test
     public void file_can_be_deleted() {
-        String path = "./public/dog/1";
+        String path = "./public/test/1";
         String body = "Dog Breed: Corgi";
         fileHandler.writeFile(path, "txt", body.getBytes());
 
 
-        String deleteThisPath = "./public/dog/1.txt";
+        String deleteThisPath = "./public/test/1.txt";
         fileHandler.deleteFile(deleteThisPath);
-        assertEquals(null, fileHandler.readFile("./public/dog/1.txt"));
+        assertEquals(null, fileHandler.readFile("./public/test/1.txt"));
     }
 
 
     @Test
     public void directory_can_be_deleted() {
-        String path = "./public/dog/1";
+        String path = "./public/test/1";
         String body = "Dog Breed: Corgi";
         fileHandler.writeFile(path, "txt", body.getBytes());
 
-        String deleteThisPath = "./public/dog";
+        String deleteThisPath = "./public/test";
         fileHandler.deleteDirectory(deleteThisPath);
-        assertEquals(null, fileHandler.readFile("./public/dog/1.txt"));
-        assertEquals(null, fileHandler.readFile("./public/dog"));
+        assertEquals(null, fileHandler.readFile("./public/test/1.txt"));
+        assertEquals(null, fileHandler.readFile("./public/test"));
+    }
+
+    @Test
+    public void directory_can_read_subfolders() {
+        String path = "./public/test/1";
+        String body = "Dog Breed: Corgi";
+        fileHandler.writeFile(path, "txt", body.getBytes());
+
+        String path2 = "./public/test/2";
+        String body2 = "<h1>CAT Breed: Corgi</h1>";
+        fileHandler.writeFile(path2, "html", body2.getBytes());
+
+
+        String basePath = "./public/";
+
+        assertEquals(true, fileHandler.readDirectoryContents(basePath).contains("Home.html"));
+        assertEquals(true, fileHandler.readDirectoryContents(basePath).contains("TurtleTab.txt"));
+        assertEquals(true, fileHandler.readDirectoryContents(basePath).contains("japan.png"));
+        assertEquals(true, fileHandler.readDirectoryContents(basePath).contains("water.png"));
+        assertEquals(true, fileHandler.readDirectoryContents(basePath).contains("test/2.html"));
+        assertEquals(true, fileHandler.readDirectoryContents(basePath).contains("test/1.txt"));
     }
 }

--- a/src/test/java/repository/FileRepositoryTest.java
+++ b/src/test/java/repository/FileRepositoryTest.java
@@ -1,41 +1,45 @@
-package file_handler;
+package repository;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class FileHandlerTest {
+public class FileRepositoryTest {
+    FileRepository fileHandler = new FileRepository();
+
     @Test
     public void static_files_in_public_directory_are_rendered_as_a_HTML_page_with_contents_listed() {
         String path = "./public";
 
-        assertEquals(true, FileHandler.readDirectoryContents(path).contains("Home.html"));
-        assertEquals(true, FileHandler.readDirectoryContents(path).contains("TurtleTab.txt"));
-        assertEquals(true, FileHandler.readDirectoryContents(path).contains("japan.png"));
-        assertEquals(true, FileHandler.readDirectoryContents(path).contains("water.png"));
+        assertEquals(true, fileHandler.readDirectoryContents(path).contains("Home.html"));
+        assertEquals(true, fileHandler.readDirectoryContents(path).contains("TurtleTab.txt"));
+        assertEquals(true, fileHandler.readDirectoryContents(path).contains("japan.png"));
+        assertEquals(true, fileHandler.readDirectoryContents(path).contains("water.png"));
     }
 
     @Test
     public void html_file_can_be_read_from_public_directory() {
         String path = "./public/Home.html";
-        String homeHTML = "<!DOCTYPE html>" +
-                "<html lang=\"en\">" +
-                "<head>" +
-                "    <meta charset=\"UTF-8\">" +
-                "    <title>Home Page</title>" +
-                "</head>" +
-                "<body BGCOLOR=\"FFFFFF\">" +
-                "<h1>HELLO!!</h1>" +
-                "<p>This is a very simple HTML document</p>" +
-                "<p>It only has two paragraphs</p>" +
-                "</body>" +
+        String homeHTML = "<!DOCTYPE html>\n" +
+                "<html lang=\"en\">\n" +
+                "<head>\n" +
+                "    <meta charset=\"UTF-8\">\n" +
+                "    <title>Home Page</title>\n" +
+                "</head>\n" +
+                "<body BGCOLOR=\"FFFFFF\">\n" +
+                "\n" +
+                "<h1>HELLO!!</h1>\n" +
+                "<p>This is a very simple HTML document</p>\n" +
+                "<p>It only has two paragraphs</p>\n" +
+                "\n" +
+                "</body>\n" +
                 "</html>";
-        assertEquals(homeHTML, FileHandler.getFileContents(path));
+        assertEquals(homeHTML, new String(fileHandler.readFile(path)));
     }
 
     @Test
     public void html_type_can_be_determined() {
         String path = "./public/Home.html";
-        assertEquals("text/html", FileHandler.getFileType(path));
+        assertEquals("text/html", fileHandler.getFileType(path));
     }
 
     @Test
@@ -43,19 +47,19 @@ public class FileHandlerTest {
         String path = "./public/TurtleTab.txt";
         String homeHTML = "TurtleTab is a Google Chrome Extension Built with React. It creates a new homepage which " +
                 "features current Weather, Todo and Notes functionality. It also accesses your browser data to see Bookmarks, enable/disable Apps and Extensions, and see/clear your History. It is a collaborative effort by a remote team of aspiring developers who met on Chingu, an international community of coders.";
-        assertEquals(homeHTML, FileHandler.getFileContents(path));
+        assertEquals(homeHTML, new String(fileHandler.readFile(path)));
     }
 
     @Test
     public void text_type_can_be_determined() {
         String path = "./public/TurtleTab.txt";
-        assertEquals("text/plain", FileHandler.getFileType(path));
+        assertEquals("text/plain", fileHandler.getFileType(path));
     }
 
     @Test
     public void image_file_can_be_read_from_public_directory() {
         String path = "./public/water.png";
-        byte[] image = FileHandler.readFile(path);
+        byte[] image = fileHandler.readFile(path);
         int imageContentLength = 1448876;
         assertEquals(imageContentLength, image.length);
     }
@@ -63,33 +67,33 @@ public class FileHandlerTest {
     @Test
     public void image_type_can_be_determined() {
         String path = "./public/japan.png";
-        assertEquals("image/png", FileHandler.getFileType(path));
+        assertEquals("image/png", fileHandler.getFileType(path));
     }
 
     @Test
     public void file_can_be_written_to_directory() {
         String path = "./public/dog/1";
         String body = "Dog Breed: Corgi";
-        FileHandler.writeFile(path, "txt", body.getBytes());
-        assertEquals(body, new String(FileHandler.readFile("./public/dog/1.txt")));
+        fileHandler.writeFile(path, "txt", body.getBytes());
+        assertEquals(body, new String(fileHandler.readFile("./public/dog/1.txt")));
     }
 
     @Test
     public void path_can_trim_last_resource() {
         String path = "./public/dog/1";
-        assertEquals("./public/dog", FileHandler.trimLastResource(path));
+        assertEquals("./public/dog", Repository.trimLastResource(path));
     }
 
     @Test
     public void file_can_be_deleted() {
         String path = "./public/dog/1";
         String body = "Dog Breed: Corgi";
-        FileHandler.writeFile(path, "txt", body.getBytes());
+        fileHandler.writeFile(path, "txt", body.getBytes());
 
 
         String deleteThisPath = "./public/dog/1.txt";
-        FileHandler.deleteFile(deleteThisPath);
-        assertEquals(null, FileHandler.readFile("./public/dog/1.txt"));
+        fileHandler.deleteFile(deleteThisPath);
+        assertEquals(null, fileHandler.readFile("./public/dog/1.txt"));
     }
 
 
@@ -97,11 +101,11 @@ public class FileHandlerTest {
     public void directory_can_be_deleted() {
         String path = "./public/dog/1";
         String body = "Dog Breed: Corgi";
-        FileHandler.writeFile(path, "txt", body.getBytes());
+        fileHandler.writeFile(path, "txt", body.getBytes());
 
         String deleteThisPath = "./public/dog";
-        FileHandler.deleteDirectory(deleteThisPath);
-        assertEquals(null, FileHandler.readFile("./public/dog/1.txt"));
-        assertEquals(null, FileHandler.readFile("./public/dog"));
+        fileHandler.deleteDirectory(deleteThisPath);
+        assertEquals(null, fileHandler.readFile("./public/dog/1.txt"));
+        assertEquals(null, fileHandler.readFile("./public/dog"));
     }
 }

--- a/src/test/java/repository/MockFile.java
+++ b/src/test/java/repository/MockFile.java
@@ -1,0 +1,25 @@
+package repository;
+
+public class MockFile {
+    private String name;
+    private String type;
+    private byte[] content;
+
+    public MockFile(String name, String type, byte[] content) {
+        this.name = name;
+        this.type = type;
+        this.content = content;
+    }
+
+    public String name() {
+        return name;
+    }
+
+    public String type() {
+        return type;
+    }
+
+    public byte[] content() {
+        return content;
+    }
+}

--- a/src/test/java/repository/MockRepositoryTest.java
+++ b/src/test/java/repository/MockRepositoryTest.java
@@ -1,0 +1,65 @@
+package repository;
+
+import http_protocol.MIMETypes;
+import mocks.MockRepository;
+import org.junit.jupiter.api.Test;
+import java.util.List;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class MockRepositoryTest {
+    MockRepository repository = new MockRepository("/public");
+
+    @Test
+    public void repository_can_read_from_a_directory() {
+        List<String> directoryContents = repository.readDirectoryContents("/public");
+
+        assertEquals(true, directoryContents.contains("Home.html"));
+        assertEquals(true, directoryContents.contains("TurtleTab.txt"));
+        assertEquals(true, directoryContents.contains("water.png"));
+        assertEquals(true, directoryContents.contains("japan.png"));
+    }
+
+    @Test
+    public void repository_can_read_from_a_prepended_directory() {
+        List<String> directoryContents = repository.readDirectoryContents("./public");
+
+        assertEquals(true, directoryContents.contains("Home.html"));
+        assertEquals(true, directoryContents.contains("TurtleTab.txt"));
+        assertEquals(true, directoryContents.contains("water.png"));
+        assertEquals(true, directoryContents.contains("japan.png"));
+    }
+
+    @Test
+    public void repository_can_read_a_file_given_a_path() {
+        String turtleText = "TurtleTabs a Google";
+
+        assertEquals(turtleText, new String(repository.readFile("./public/TurtleTab.txt")));
+    }
+
+    @Test
+    public void repository_can_write_to_directory() {
+        byte[] newContent = "test content".getBytes();
+        repository.writeFile("./public/test_file.txt", MIMETypes.plain, newContent);
+        assertEquals(newContent, repository.readFile("./public/test_file.txt"));
+    }
+
+    @Test
+    public void repository_can_get_file_type() {
+        assertEquals(MIMETypes.png, repository.getFileType("./public/water.png"));
+    }
+
+    @Test
+    public void repository_can_delete_file() {
+        byte[] newContent = "test content".getBytes();
+        repository.writeFile("./public/test_file.txt", MIMETypes.plain, newContent);
+        repository.deleteFile("./public/test_file.txt");
+        assertThrows(NullPointerException.class, () -> repository.readFile("./public/test_file.txt"));
+    }
+
+    @Test
+    public void repository_can_format_path() {
+        String invalidPath = "/Users/fsadikin/Documents/java_http_server/public/dog/1";
+        assertEquals("/public/dog/1", repository.validatedPath(invalidPath));
+    }
+}

--- a/src/test/java/repository/MockRepositoryTest.java
+++ b/src/test/java/repository/MockRepositoryTest.java
@@ -2,13 +2,24 @@ package repository;
 
 import http_standards.MIMETypes;
 import mocks.MockRepository;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
 import java.util.List;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class MockRepositoryTest {
-    MockRepository repository = new MockRepository("/public");
+    MockRepository repository;
+
+    @BeforeEach
+    public void cleanRepository() {
+        repository = new MockRepository("/public");
+        repository.writeFile("./public/Home.html", MIMETypes.html, "<!DOCTYPE html>\n".getBytes());
+        repository.writeFile("./public/TurtleTab.txt", MIMETypes.plain, "TurtleTabs a Google".getBytes());
+        repository.writeFile("./public/water.png", MIMETypes.png, "water image".getBytes());
+        repository.writeFile("./public/japan.png", MIMETypes.png, "japan image".getBytes());
+    }
 
     @Test
     public void repository_can_read_from_a_directory() {

--- a/src/test/java/repository/MockRepositoryTest.java
+++ b/src/test/java/repository/MockRepositoryTest.java
@@ -1,6 +1,6 @@
 package repository;
 
-import http_protocol.MIMETypes;
+import http_standards.MIMETypes;
 import mocks.MockRepository;
 import org.junit.jupiter.api.Test;
 import java.util.List;


### PR DESCRIPTION
Repository interface with FileRepository (for live file manipulations) and MockRepository (in memory files, for testing purposes).

Remove FileHandler, and pass in Repository as a dependency to Router. Defaults to FileRepository, but can set a new repository as needed.