### PR TITLE
Add handling of request parameters feature

### DIFF
--- a/src/main/java/application/App.java
+++ b/src/main/java/application/App.java
@@ -35,11 +35,11 @@ public class App {
         app.head("/get_with_body", (Request request, Response response) -> {
             String bodyContent = "Here are all my favorite movies:\n" + "- Harry " +
                     "Potter\n";
-            response.head(bodyContent.getBytes(), MIMETypes.plain);
+            response.head(bodyContent, MIMETypes.plain);
         });
 
         app.post("/echo_body", (Request request, Response response) -> {
-            response.sendBody(request.getBody().getBytes(), request.getContentFileType());
+            response.sendBody(request.getBody(), request.getContentFileType());
             response.setStatus(StatusCode.ok);
         });
 
@@ -62,18 +62,18 @@ public class App {
         app.post("/dog", (Request request, Response response) -> {
             String uniqueRoute = app.getUniqueRoute(request.getRoute());
             String resourceRoute = app.saveResource(uniqueRoute, request.getContentFileType(),
-                    request.getBody().getBytes());
+                    request.getBody());
             response.successfulPost(resourceRoute);
         });
 
         app.put("/cat/1", (Request request, Response response) -> {
-            app.saveResource(request.getRoute(), request.getContentFileType(), request.getBody().getBytes());
+            app.saveResource(request.getRoute(), request.getContentFileType(), request.getBody());
             response.successfulPut();
         });
 
         app.get("/multiple_parameters", (Request request, Response response) -> {
             String body = "Parameters: \n" + request.getParameters().entrySet();
-            response.sendBody(body.getBytes(), MIMETypes.plain);
+            response.sendBody(body, MIMETypes.plain);
         });
 
         return app;

--- a/src/main/java/application/App.java
+++ b/src/main/java/application/App.java
@@ -71,6 +71,11 @@ public class App {
             response.successfulPut();
         });
 
+        app.get("/multiple_parameters", (Request request, Response response) -> {
+            String body = "Parameters: \n" + request.getParameters().entrySet();
+            response.sendBody(body.getBytes(), MIMETypes.plain);
+        });
+
         return app;
     }
 

--- a/src/main/java/http_server/Request.java
+++ b/src/main/java/http_server/Request.java
@@ -10,12 +10,16 @@ public class Request {
     private String route;
     private String body;
     private HashMap<String, String> headers;
+    private HashMap<String, String> parameters;
 
-    public Request(String method, String route, String body, HashMap<String, String> headers) {
+    public Request(String method, String route, String body, HashMap<String, String> headers,
+                   HashMap<String, String> parameters) {
         this.method = method;
         this.route = route;
         this.body = body;
         this.headers = headers;
+        this.parameters = parameters;
+
     }
 
     public String getMethod() {
@@ -32,6 +36,10 @@ public class Request {
 
     public HashMap<String, String> getHeaders() {
         return headers;
+    }
+
+    public HashMap<String, String> getParameters() {
+        return parameters;
     }
 
     public String getContentFileType() {

--- a/src/main/java/http_server/ResourceHandler.java
+++ b/src/main/java/http_server/ResourceHandler.java
@@ -1,0 +1,63 @@
+package http_server;
+
+import directory_page_creator.DirectoryPageCreator;
+import http_standards.MIMETypes;
+import repository.Repository;
+
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.List;
+
+public class ResourceHandler {
+    private static Path fullStaticDirectoryPath;
+    private static String directoryPath;
+    private static Router router;
+
+    public ResourceHandler(Router router, String directoryPath) {
+        this.router = router;
+        this.fullStaticDirectoryPath = router.getFullStaticDirectoryPath();
+        this.directoryPath = directoryPath;
+    }
+
+    public void createStaticDirectory(String staticDirectoryRelativePath) {
+        List<String> directoryContents = router.getRepository().readDirectoryContents(fullStaticDirectoryPath.toString());
+        createStaticResourceRoute(directoryContents, staticDirectoryRelativePath);
+        createStaticDirectoryRoute(staticDirectoryRelativePath);
+    }
+
+    public void save(String resourcePath, String fileType, byte[] content) {
+        router.getRepository().writeFile(fullStaticDirectoryPath + resourcePath, fileType, content);
+    }
+
+    public void delete(String resourcePath, String fileType) {
+        router.getRepository().deleteFile(fullStaticDirectoryPath + resourcePath);
+    }
+
+    private void createStaticDirectoryRoute(String staticDirectoryRelativePath) {
+        router.get(staticDirectoryRelativePath, (Request request, Response response) -> {
+            List<String> directoryContents = router.getRepository().readDirectoryContents(fullStaticDirectoryPath.toString());
+            response.sendBody(new DirectoryPageCreator(directoryContents, staticDirectoryRelativePath).generateHTML().getBytes(), MIMETypes.html);
+        });
+    }
+
+    private void createStaticResourceRoute(List<String> directoryContents, String staticDirectoryRelativePath) {
+        for (int i = 0; i < directoryContents.size(); i++) {
+            String fileName = directoryContents.get(i);
+            String filePath = staticDirectoryRelativePath + "/" + fileName;
+
+            router.get(filePath, (Request request, Response response) -> {
+                response.sendFile("/" + fileName);
+            });
+        }
+    }
+
+    public List<String> paths(String resourcePath, String fileType) {
+        return Arrays.asList(
+                resourcePath,
+                resourcePath + "." + fileType,
+                directoryPath + resourcePath,
+                directoryPath + resourcePath + "." + fileType
+        );
+    }
+
+}

--- a/src/main/java/http_server/Response.java
+++ b/src/main/java/http_server/Response.java
@@ -67,16 +67,16 @@ public class Response {
     }
 
     private void notFound() {
-        this.status = StatusCode.notFound;
+        setStatus(StatusCode.notFound);
     }
 
     private void methodNotAllowed() {
-        this.status = StatusCode.methodNotAllowed;
+        setStatus(StatusCode.methodNotAllowed);
         setHeader(Headers.allowedHeaders, router.createOptionsHeader(request.getRoute()));
     }
 
     private void noContent() {
-        this.status = StatusCode.noContent;
+        setStatus(StatusCode.noContent);
     }
 
     public void sendFile(String path) {
@@ -88,7 +88,7 @@ public class Response {
     }
 
     public void redirect(String redirectedRoute) {
-        status = StatusCode.moved;
+        setStatus(StatusCode.moved);
         setHeader(Headers.location, "http://127.0.0.1:5000" + redirectedRoute);
     }
 
@@ -98,18 +98,26 @@ public class Response {
         this.body = bodyContent;
     }
 
+    public void sendBody(String bodyContent, String contentType) {
+        sendBody(bodyContent.getBytes(), contentType);
+    }
+
     public void successfulPut() {
         this.status = StatusCode.created;
     }
 
     public void successfulPost(String resourceLocation) {
         setHeader(Headers.location, resourceLocation);
-        this.status = StatusCode.created;
+        setStatus(StatusCode.created);
     }
 
     public void head(byte[] bodyContent, String contentType) {
         setHeader(Headers.contentLength, Integer.toString(bodyContent.length));
         setHeader(Headers.contentType, contentType);
+    }
+
+    public void head(String bodyContent, String contentType) {
+        head(bodyContent.getBytes(), contentType);
     }
 
     public void successfulDelete() {

--- a/src/main/java/http_server/Response.java
+++ b/src/main/java/http_server/Response.java
@@ -46,7 +46,6 @@ public class Response {
             return false;
         }
 
-
         return true;
     }
 

--- a/src/main/java/http_standards/Parser.java
+++ b/src/main/java/http_standards/Parser.java
@@ -1,5 +1,7 @@
 package http_standards;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.HashMap;
 
 public class Parser {
@@ -40,11 +42,38 @@ public class Parser {
     }
 
     public static String getRoute(String request) {
-        return getFirstLine(request)[1];
+        String routeLine =  getFirstLine(request)[1];
+        if (routeLine.contains("?")) {
+            int paramIndex = routeLine.indexOf("?");
+            return routeLine.substring(0, paramIndex);
+        }
+        return routeLine;
     }
 
     public static String getStatusCode(String request) {
         return Parser.getFirstLine(request)[1];
+    }
+
+    public static HashMap<String, String> getParameters(String request) {
+        HashMap<String, String> parametersCollection = new HashMap<>();
+        String routeLine = getFirstLine(request)[1];
+
+        if (routeLine.contains("?")) {
+            int startOfParametersIndex = routeLine.indexOf("?");
+            String encodedParameters = routeLine.substring(startOfParametersIndex + 1);
+            try {
+                String decodedParameters = URLDecoder.decode(encodedParameters, "UTF-8");
+                String[] parameterSets = decodedParameters.split("[&]");
+                for (int i = 0; i < parameterSets.length; i++) {
+                    String[] keyValuePair = parameterSets[i].split("=");
+                    parametersCollection.put(keyValuePair[0], keyValuePair[1]);
+                }
+            } catch (UnsupportedEncodingException e) {
+                System.err.println(e);
+            }
+        }
+
+        return parametersCollection;
     }
 
     private static String[] splitMessage(String request) {

--- a/src/main/java/http_standards/Parser.java
+++ b/src/main/java/http_standards/Parser.java
@@ -62,11 +62,12 @@ public class Parser {
             int startOfParametersIndex = routeLine.indexOf("?");
             String encodedParameters = routeLine.substring(startOfParametersIndex + 1);
             try {
-                String decodedParameters = URLDecoder.decode(encodedParameters, "UTF-8");
-                String[] parameterSets = decodedParameters.split("[&]");
+                String[] parameterSets = encodedParameters.split("[&]");
                 for (int i = 0; i < parameterSets.length; i++) {
                     String[] keyValuePair = parameterSets[i].split("=");
-                    parametersCollection.put(keyValuePair[0], keyValuePair[1]);
+                    String key = URLDecoder.decode(keyValuePair[0], "UTF-8");
+                    String value = keyValuePair.length > 1 ? URLDecoder.decode(keyValuePair[1], "UTF-8") : "";
+                    parametersCollection.put(key, value);
                 }
             } catch (UnsupportedEncodingException e) {
                 System.err.println(e);

--- a/src/main/java/http_standards/RequestCreator.java
+++ b/src/main/java/http_standards/RequestCreator.java
@@ -8,7 +8,8 @@ public class RequestCreator {
                 Parser.getMethod(request),
                 Parser.getRoute(request),
                 Parser.getBody(request),
-                Parser.getHeaders(request)
+                Parser.getHeaders(request),
+                Parser.getParameters(request)
         );
     }
 }

--- a/src/main/java/repository/FileRepository.java
+++ b/src/main/java/repository/FileRepository.java
@@ -51,7 +51,6 @@ public class FileRepository implements Repository {
             for (Path file: stream) {
                 if (file.toFile().isFile()) {
                     String name = file.toString();
-                    System.err.println(path);
                     fileList.add(name.substring(dirPath.endsWith("/") ? dirPath.length() : dirPath.length() + 1));
                 } else {
                     List<String> subContents = readDirectoryContents(file.toString(), dirPath);
@@ -88,7 +87,7 @@ public class FileRepository implements Repository {
         Charset charset = Charset.forName("US-ASCII");
         if (isRegularExecutableFile) {
             try (BufferedReader reader = Files.newBufferedReader(file, charset)) {
-                String line = null;
+                String line;
                 while ((line = reader.readLine()) != null) {
                     fileContents += line;
                 }
@@ -147,7 +146,7 @@ public class FileRepository implements Repository {
 
         try {
             Files.delete(path);
-            System.err.println("DELETED");
+            System.err.println("Deleted " + path);
         } catch (DirectoryNotEmptyException x) {
             System.err.format("%s not empty%n", path);
         } catch (IOException x) {

--- a/src/test/java/directory_page_creator/DirectoryPageCreatorTest.java
+++ b/src/test/java/directory_page_creator/DirectoryPageCreatorTest.java
@@ -25,7 +25,6 @@ public class DirectoryPageCreatorTest {
     public void static_files_in_public_directory_are_rendered_as_a_HTML_page_with_contents_listed() {
         String path = "./public";
         List<String> directoryContents = repository.readDirectoryContents(path);
-        System.err.println(directoryContents);
         DirectoryPageCreator directoryPageCreator = new DirectoryPageCreator(directoryContents, "/public");
         String page = directoryPageCreator.generateHTML();
         String homeList = "<li class='bullets'><a href='/public/Home.html'>Home.html</a></li>\n";

--- a/src/test/java/http_server/RequestTest.java
+++ b/src/test/java/http_server/RequestTest.java
@@ -71,4 +71,37 @@ public class RequestTest {
     public void request_with_NO_body_parse_body() {
         assertEquals(null, h_request.getBody());
     }
+
+    @Test
+    public void request_can_parse_url_parameters() {
+        Request request = RequestCreator.from("GET /dog/1?name=Buddy&breed=Corgi");
+
+        HashMap<String, String> parameters = request.getParameters();
+
+        assertEquals("/dog/1", request.getRoute());
+        assertEquals("Buddy", parameters.get("name"));
+        assertEquals("Corgi", parameters.get("breed"));
+    }
+
+    @Test
+    public void request_can_parse_empty_parameters() {
+        Request request = RequestCreator.from("GET /dog/1");
+
+        HashMap<String, String> parameters = request.getParameters();
+
+        assertEquals("/dog/1", request.getRoute());
+        assertEquals(new HashMap<>(), request.getParameters());
+    }
+
+    @Test
+    public void request_can_parse_url_encoded_parameters() {
+        Request request = RequestCreator.from("GET /dog/1?message%3DHello%20G%C3%BCnter%26author%3D%40Mrs%20JK" +
+                "%20Rowling");
+
+        HashMap<String, String> parameters = request.getParameters();
+
+        assertEquals("/dog/1", request.getRoute());
+        assertEquals("Hello Günter", parameters.get("message"));
+        assertEquals("@Mrs JK Rowling", parameters.get("author"));
+    }
 }

--- a/src/test/java/http_server/RequestTest.java
+++ b/src/test/java/http_server/RequestTest.java
@@ -92,12 +92,41 @@ public class RequestTest {
 
     @Test
     public void request_can_parse_url_encoded_parameters() {
-        Request request = RequestCreator.from("GET /dog/1?message%3DHello%20G%C3%BCnter%26author%3D%40Mrs%20JK" +
-                "%20Rowling");
+        Request request = RequestCreator.from("GET /dog/1?message=Hello%20G%C3%BCnter&author=%40Mrs%20JK%20Rowling");
         HashMap<String, String> parameters = request.getParameters();
 
         assertEquals("/dog/1", request.getRoute());
         assertEquals("Hello Günter", parameters.get("message"));
         assertEquals("@Mrs JK Rowling", parameters.get("author"));
     }
+
+    @Test
+    public void request_can_parse_long_url_encoded_parameters() {
+        Request request = RequestCreator.from("GET /dog/1?variable_1=Operators%20%3C%2C%20%3E%2C%20%3D%2C%20!%3D%3B%20%2B%2C%20-%2C%20*%2C%20%26%2C%20%40%2C%20%23%2C%20%24%2C%20%5B%2C%20%5D%3A%20%22is%20that%20all%22%3F&variable_2=stuff");
+        HashMap<String, String> parameters = request.getParameters();
+
+        assertEquals("/dog/1", request.getRoute());
+        assertEquals("Operators <, >, =, !=; +, -, *, &, @, #, $, [, ]: \"is that all\"?", parameters.get("variable_1"));
+        assertEquals("stuff", parameters.get("variable_2"));
+    }
+
+    @Test
+    public void request_can_handle_incorrect_url_encoded_parameters() {
+        Request request = RequestCreator.from("GET /dog/1?message=Hello%20G%C3%BCnter&author=");
+        HashMap<String, String> parameters = request.getParameters();
+
+        assertEquals("/dog/1", request.getRoute());
+        assertEquals("Hello Günter", parameters.get("message"));
+        assertEquals("", parameters.get("author"));
+    }
+
+    @Test
+    public void request_can_handle_incorrect_url_encoded_parameters_2() {
+        Request request = RequestCreator.from("GET /dog/1?message=Hello%20G%C3%BCnter&");
+        HashMap<String, String> parameters = request.getParameters();
+
+        assertEquals("/dog/1", request.getRoute());
+        assertEquals("Hello Günter", parameters.get("message"));
+    }
 }
+

--- a/src/test/java/http_server/RequestTest.java
+++ b/src/test/java/http_server/RequestTest.java
@@ -75,7 +75,6 @@ public class RequestTest {
     @Test
     public void request_can_parse_url_parameters() {
         Request request = RequestCreator.from("GET /dog/1?name=Buddy&breed=Corgi");
-
         HashMap<String, String> parameters = request.getParameters();
 
         assertEquals("/dog/1", request.getRoute());
@@ -87,8 +86,6 @@ public class RequestTest {
     public void request_can_parse_empty_parameters() {
         Request request = RequestCreator.from("GET /dog/1");
 
-        HashMap<String, String> parameters = request.getParameters();
-
         assertEquals("/dog/1", request.getRoute());
         assertEquals(new HashMap<>(), request.getParameters());
     }
@@ -97,7 +94,6 @@ public class RequestTest {
     public void request_can_parse_url_encoded_parameters() {
         Request request = RequestCreator.from("GET /dog/1?message%3DHello%20G%C3%BCnter%26author%3D%40Mrs%20JK" +
                 "%20Rowling");
-
         HashMap<String, String> parameters = request.getParameters();
 
         assertEquals("/dog/1", request.getRoute());

--- a/src/test/java/http_server/ServerTest.java
+++ b/src/test/java/http_server/ServerTest.java
@@ -241,7 +241,6 @@ public class ServerTest {
                 () -> {
                     String request = "GET /dog/1.html HTTP/1.1";
                     String response = runSessionAndRetrieveResponse(request);
-                    System.err.println(response);
 
                     assertEquals("200", Parser.getStatusCode(response));
                     assertEquals("text/html", Parser.getHeaders(response).get("Content-Type"));
@@ -358,6 +357,24 @@ public class ServerTest {
                 },
                 () -> {
                     String request = "GET /delete_me.txt HTTP/1.1";
+                    String response = runSessionAndRetrieveResponse(request);
+
+                    assertEquals("404", Parser.getStatusCode(response));
+                },
+                () -> {
+                    String request = "GET /delete_me HTTP/1.1";
+                    String response = runSessionAndRetrieveResponse(request);
+
+                    assertEquals("404", Parser.getStatusCode(response));
+                },
+                () -> {
+                    String request = "GET /public/delete_me.txt HTTP/1.1";
+                    String response = runSessionAndRetrieveResponse(request);
+
+                    assertEquals("404", Parser.getStatusCode(response));
+                },
+                () -> {
+                    String request = "GET /public/delete_me HTTP/1.1";
                     String response = runSessionAndRetrieveResponse(request);
 
                     assertEquals("404", Parser.getStatusCode(response));

--- a/src/test/java/http_server/ServerTest.java
+++ b/src/test/java/http_server/ServerTest.java
@@ -384,7 +384,7 @@ public class ServerTest {
 
     @Test
     public void server_can_handle_request_parameters() {
-        String route = "/multiple_parameters?message%3DHello%20G%C3%BCnter%26author%3D%40Mrs%20JK%20Rowling";
+        String route = "/multiple_parameters?message=Hello%20G%C3%BCnter&author=%40Mrs%20JK%20Rowling";
         String request = "GET " + route + " HTTP/1.1";
         String response = runSessionAndRetrieveResponse(request);
 

--- a/src/test/java/http_server/ServerTest.java
+++ b/src/test/java/http_server/ServerTest.java
@@ -364,4 +364,15 @@ public class ServerTest {
                 }
         );
     }
+
+    @Test
+    public void server_can_handle_request_parameters() {
+        String route = "/multiple_parameters?message%3DHello%20G%C3%BCnter%26author%3D%40Mrs%20JK%20Rowling";
+        String request = "GET " + route + " HTTP/1.1";
+        String response = runSessionAndRetrieveResponse(request);
+
+        assertEquals("200", Parser.getStatusCode(response));
+        assertEquals(true, Parser.getBody(response).contains("author=@Mrs JK Rowling"));
+        assertEquals(true, Parser.getBody(response).contains("message=Hello Günter"));
+    }
 }

--- a/src/test/java/mocks/MockRepository.java
+++ b/src/test/java/mocks/MockRepository.java
@@ -41,7 +41,6 @@ public class MockRepository implements Repository  {
         memoryRepository.put(intendedFilePath, new MockFile(fileName, validatedFileType, fileContents));
     }
 
-
     public void deleteFile(String filePath) {
         memoryRepository.remove(validatedPath(filePath));
     }

--- a/src/test/java/mocks/MockRouter.java
+++ b/src/test/java/mocks/MockRouter.java
@@ -72,6 +72,11 @@ public class MockRouter {
             response.successfulPut();
         });
 
+        app.get("/multiple_parameters", (Request request, Response response) -> {
+            String body = "Parameters: \n" + request.getParameters().entrySet();
+            response.sendBody(body.getBytes(), MIMETypes.plain);
+        });
+
         return app;
     }
 }


### PR DESCRIPTION
### Request parameters need to follow this format: `<route>?key=value&key2=value2` etc. 
### This feature also supports URL encoded characters (for example @ or spaces).

- Update Request to have parameters collection
- Update Parser to handle parsing of request parameters.